### PR TITLE
editorial: address AD review comments for ACME DA

### DIFF
--- a/draft-ietf-acme-device-attest.md
+++ b/draft-ietf-acme-device-attest.md
@@ -87,7 +87,7 @@ Many operating systems and device vendors offer functionality enabling a device 
 - [Trusted Platform Module](https://trustedcomputinggroup.org/resource/trusted-platform-module-tpm-summary/)
 - [Managed Device Attestation for Apple Devices](https://support.apple.com/en-om/guide/deployment/dep28afbde6a/web)
 
-Using ACME and device attestation to issue client certificates for enterprise PKI is to be a common use case. The following variances to the ACME specification are described in this document:
+Using ACME and device attestation to issue client certificates for enterprise PKI will be a common use case. The following variances to the ACME specification are described in this document:
 
 - Addition of `permanent-identifier` {{!RFC4043}} and `hardware-module` {{!RFC4108}} identifier types.
 - Addition of the `device-attest-01` challenge type to prove control of the `permanent-identifier` and `hardware-module` identifier types.
@@ -119,7 +119,7 @@ device-identifier-value = 1*(%x00-2E / %x30-FF)
 permanent-identifier-value = device-identifier-value ["/" assigner-value]
 ~~~
 
-A valid `permanent-identifier-value` value is a UTF-8 string that contains an identity consisting of one or more characters without any forward-slash "/" (UTF-8: U+002F) characters. Optionally, a forward-slash "/" character and "dotted-decimal" object identifier identifying the assigner may follow the identity.
+A valid `permanent-identifier-value` value is a UTF-8 string that contains an identity consisting of one or more characters without any forward-slash "/" (UTF-8: U+002F) characters. Optionally, a forward-slash "/" character and "dotted-decimal" object identifier identifying the assigner may follow the identity. The assigner-value is a dotted-decimal representation of an ASN.1 OBJECT IDENTIFIER.
 
 The Server MUST verify that identifier values in newOrder requests conform to the `permanent-identifier-value` production rule and MUST reject requests containing non-conforming values with a "malformed" error.
 
@@ -141,13 +141,13 @@ Example identifier with an assigner:
 }
 ~~~
 
-## Representation in Certificate Signing Requests and X.509 Certificates
+## Representation in Certificate Signing Requests (CSRs) and X.509 Certificates
 
 This section describes the X.509 representation of the `permanent-identifier`. Other credential types may use the same identifier values with representations appropriate to those credential types.
 
 The identity is included in the Subject Alternative Name Extension using the `identifierValue` field of the PermanentIdentifier form described in {{!RFC4043}}. Although {{!RFC4043}} permits the requester to include the `identifierValue` in a `serialNumber` subject attribute, this specification mandates that the `identifierValue` field of the PermanentIdentifier MUST be present and MUST contain the identifier.
 
-The value of the `identifierValue` field of the PermanentIdentifier MUST be an octet-for-octet match of the `device-identifier-value` value as encoded in the Order resource. If the `assigner-value` value is included in the identifier as encoded in the Order resource, then the `assigner` field of the PermanentIdentifier MUST be the encoding of the "dotted-decimal" object identifier encoded as the `assigner-value` value.
+The value of the `identifierValue` field of the PermanentIdentifier MUST exactly match (no normalization, case folding, or encoding transformation is permitted) the `device-identifier-value` value as encoded in the Order resource. If the `assigner-value` value is included in the identifier as encoded in the Order resource, then the `assigner` field of the PermanentIdentifier MUST be the encoding of the "dotted-decimal" object identifier encoded as the `assigner-value` value.
 
 To ensure that the identifier as presented in the Order resource and CSR match, the Server MUST perform the logical equivalent of extracting the `device-identifier-value` and `assigner-value` values from the CSR and reconstructing the UTF-8 representation of the identifier. The Server MUST then ensure that the UTF-8 representation and the identifier presented in the Order resource are an octet-for-octet match and reject the Order otherwise. Servers that derive identifier values directly from verified attestation evidence and construct the certificate SAN from that evidence, provided the derived values are verified against the attested device identity in the attestation statement, satisfy the intent of this requirement.
 
@@ -201,7 +201,7 @@ The hardware module identity is included in the Subject Alternate Name Extension
 - hwType: An OBJECT IDENTIFIER that identifies the type of hardware module
 - hwSerialNum: An OCTET STRING containing the hardware module serial number
 
-The value of the `hwSerialNum` field of the HardwareModuleName MUST be an octet-for-octet match of the `hw-serial-num-value` value as encoded in the Order resource. If the `hw-type-value` value is included in the identifier as encoded in the Order resource, then the `hwType` field of the HardwareModuleName MUST be the encoding of the "dotted-decimal" object identifier encoded as the `hw-type-value` value.
+The value of the `hwSerialNum` field of the HardwareModuleName MUST exactly match (no normalization, case folding, or encoding transformation is permitted) the `hw-serial-num-value` value as encoded in the Order resource. If the `hw-type-value` value is included in the identifier as encoded in the Order resource, then the `hwType` field of the HardwareModuleName MUST be the encoding of the "dotted-decimal" object identifier encoded as the `hw-type-value` value.
 
 To ensure that the identifier as presented in the Order resource and CSR match, the Server MUST perform the logical equivalent of extracting the `hw-serial-num-value` and `hw-type-value` values from the CSR and reconstructing the UTF-8 representation of the identifier. The Server MUST then ensure that the UTF-8 representation and the identifier presented in the Order resource are an octet-for-octet match and reject the Order otherwise. Servers that derive identifier values directly from verified attestation evidence and construct the certificate SAN from that evidence, provided the derived values are verified against the attested device identity in the attestation statement, satisfy the intent of this requirement.
 
@@ -275,7 +275,8 @@ Although this document focuses guidance on implementing new identifier types and
 ## Enterprise PKI
 
 ACME was originally envisioned for issuing certificates in the Web PKI, however this extension will primarily be useful in enterprise PKI.
-<!-- TODO: ^^^ perhaps also mention/cover IoT attestation PKI usecases -->
+
+
 ### External Account Binding
 
 An enterprise CA likely only wants to receive requests from authorized devices. It is RECOMMENDED that the Server require a value for the "externalAccountBinding" field to be present in "newAccount" requests.
@@ -286,7 +287,7 @@ If an enterprise CA desires to limit the number of certificates that can be requ
 
 Enterprise deployments often consist of heterogeneous device fleets where not all devices are capable of hardware attestation. A Server MAY offer device-attest-01 alongside other challenge types within a single authorization, allowing capable devices to complete device-attest-01 while other devices complete an alternative challenge. This posture allows operators to observe fleet attestation coverage before enforcing policy and is compatible with phased deployments.
 
-Servers that issue certificates without requiring a completed device-attest-01 challenge rely on other authorization mechanisms, such as external account binding or pre-authorized accounts, to establish device identity.
+Servers can rely on other authorization mechanisms, such as external account binding or pre-authorized accounts, to establish device identity instead of requiring completion of the device-attest-01 challenge.
 
 ### Multiple Challenge Types
 

--- a/draft-ietf-acme-device-attest.md
+++ b/draft-ietf-acme-device-attest.md
@@ -12,26 +12,36 @@ keyword: Internet-Draft
 
 author:
  -
-    fullname: Brandon Weeks
+    ins: B. Weeks
+    name: Brandon Weeks
+    org: Google Inc
+    abbrev: Google Inc
     email: me@brandonweeks.com
  -
-    fullname: Ganesh Mallaya
-    company: AppViewX
+    ins: G. Mallaya
+    name: Ganesh Mallaya
+    org: AppViewX Inc.
+    abbrev: AppViewX Inc.
     email: ganesh.mallaya@appviewx.com
  -
-    fullname: Sven Rajala
-    company: Keyfactor
+    ins: S. Rajala
+    name: Sven Rajala
+    org: Keyfactor
+    abbrev: Keyfactor
     email: sven.rajala@keyfactor.com
-
  -
-    fullname: Corey Bonnell
-    company: DigiCert, Inc.
+    ins: C. Bonnell
+    name: Corey Bonnell
+    org: DigiCert, Inc.
+    abbrev: DigiCert, Inc.
     email: corey.bonnell@digicert.com
-
  -
-    fullname: Ryan Hurst
-    company: Peculiar Ventures
+    ins: R. Hurst
+    name: Ryan Hurst
+    org: Peculiar Ventures
+    abbrev: Peculiar Ventures
     email: ryan.hurst+ietf@peculiarventures.com
+
 
 normative:
   RFC4043:
@@ -269,7 +279,6 @@ Content-Type: application/jose+json
   "signature": "Q1bURgJoEslbD1c5...3pYdSMLio57mQNN4"
 }
 ~~~~~~~~~~
-
 The webauthn payload MAY contain any identifiers registered in "WebAuthn Attestation Statement Format Identifiers" and any extensions registered in "WebAuthn Extension Identifiers" [IANA-Webauthn], [RFC8809].
 
 # Operational Considerations

--- a/draft-ietf-acme-device-attest.md
+++ b/draft-ietf-acme-device-attest.md
@@ -147,7 +147,9 @@ This section describes the X.509 representation of the `permanent-identifier`. O
 
 The identity is included in the Subject Alternative Name Extension using the `identifierValue` field of the PermanentIdentifier form described in {{!RFC4043}}. Although {{!RFC4043}} permits the requester to include the `identifierValue` in a `serialNumber` subject attribute, this specification mandates that the `identifierValue` field of the PermanentIdentifier MUST be present and MUST contain the identifier.
 
-The value of the `identifierValue` field of the PermanentIdentifier MUST exactly match (no normalization, case folding, or encoding transformation is permitted) the `device-identifier-value` value as encoded in the Order resource. If the `assigner-value` value is included in the identifier as encoded in the Order resource, then the `assigner` field of the PermanentIdentifier MUST be the encoding of the "dotted-decimal" object identifier encoded as the `assigner-value` value.
+The value of the identifierValue field of the PermanentIdentifier MUST be an octet-for-octet match of the device-identifier-value value as encoded in the Order resource. If the `assigner-value` value is included in the identifier as encoded in the Order resource, then the `assigner` field of the PermanentIdentifier MUST be the encoding of the "dotted-decimal" object identifier encoded as the `assigner-value` value.
+
+This strict matching requirement ensures that the SAN in the issued certificate appears exactly as it appeared during proof-of-ownership validation, preventing identifier malleability. Serial number allocation schemes may be case-sensitive or otherwise sensitive to exact byte representation, so no normalization or transformation is permitted.
 
 To ensure that the identifier as presented in the Order resource and CSR match, the Server MUST perform the logical equivalent of extracting the `device-identifier-value` and `assigner-value` values from the CSR and reconstructing the UTF-8 representation of the identifier. The Server MUST then ensure that the UTF-8 representation and the identifier presented in the Order resource are an octet-for-octet match and reject the Order otherwise. Servers that derive identifier values directly from verified attestation evidence and construct the certificate SAN from that evidence, provided the derived values are verified against the attested device identity in the attestation statement, satisfy the intent of this requirement.
 
@@ -201,7 +203,9 @@ The hardware module identity is included in the Subject Alternate Name Extension
 - hwType: An OBJECT IDENTIFIER that identifies the type of hardware module
 - hwSerialNum: An OCTET STRING containing the hardware module serial number
 
-The value of the `hwSerialNum` field of the HardwareModuleName MUST exactly match (no normalization, case folding, or encoding transformation is permitted) the `hw-serial-num-value` value as encoded in the Order resource. If the `hw-type-value` value is included in the identifier as encoded in the Order resource, then the `hwType` field of the HardwareModuleName MUST be the encoding of the "dotted-decimal" object identifier encoded as the `hw-type-value` value.
+The value of the hwSerialNum field of the HardwareModuleName MUST be an octet-for-octet match of the hw-serial-num-value value as encoded in the Order resource. If the `hw-type-value` value is included in the identifier as encoded in the Order resource, then the `hwType` field of the HardwareModuleName MUST be the encoding of the "dotted-decimal" object identifier encoded as the `hw-type-value` value.
+
+This strict matching requirement ensures that the SAN in the issued certificate appears exactly as it appeared during proof-of-ownership validation, preventing identifier malleability. Serial number allocation schemes may be case-sensitive or otherwise sensitive to exact byte representation, so no normalization or transformation is permitted.
 
 To ensure that the identifier as presented in the Order resource and CSR match, the Server MUST perform the logical equivalent of extracting the `hw-serial-num-value` and `hw-type-value` values from the CSR and reconstructing the UTF-8 representation of the identifier. The Server MUST then ensure that the UTF-8 representation and the identifier presented in the Order resource are an octet-for-octet match and reject the Order otherwise. Servers that derive identifier values directly from verified attestation evidence and construct the certificate SAN from that evidence, provided the derived values are verified against the attested device identity in the attestation statement, satisfy the intent of this requirement.
 
@@ -287,7 +291,7 @@ If an enterprise CA desires to limit the number of certificates that can be requ
 
 Enterprise deployments often consist of heterogeneous device fleets where not all devices are capable of hardware attestation. A Server MAY offer device-attest-01 alongside other challenge types within a single authorization, allowing capable devices to complete device-attest-01 while other devices complete an alternative challenge. This posture allows operators to observe fleet attestation coverage before enforcing policy and is compatible with phased deployments.
 
-Servers can rely on other authorization mechanisms, such as external account binding or pre-authorized accounts, to establish device identity instead of requiring completion of the device-attest-01 challenge.
+Servers can rely on other authorization mechanisms, such as external account binding or pre-authorized accounts, to establish device identity instead of completing the device-attest-01 challenge.
 
 ### Multiple Challenge Types
 

--- a/draft-ietf-acme-device-attest.md
+++ b/draft-ietf-acme-device-attest.md
@@ -300,7 +300,7 @@ If an enterprise CA desires to limit the number of certificates that can be requ
 
 Enterprise deployments often consist of heterogeneous device fleets where not all devices are capable of hardware attestation. A Server MAY offer device-attest-01 alongside other challenge types within a single authorization, allowing capable devices to complete device-attest-01 while other devices complete an alternative challenge. This posture allows operators to observe fleet attestation coverage before enforcing policy and is compatible with phased deployments.
 
-Servers can rely on other authorization mechanisms, such as external account binding or pre-authorized accounts, to establish device identity instead of completing the device-attest-01 challenge.
+Servers MAY rely on other authorization mechanisms, such as external account binding or pre-authorized accounts, to establish device identity instead of completing the device-attest-01 challenge.
 
 ### Multiple Challenge Types
 


### PR DESCRIPTION
Addresses editorial and clarity comments raised during AD review. 

Addresses editorial and clarity comments raised during AD review.

Changes:
- Section 1: Replace "is to be a common use case" with "will be" (cleaner phrasing)
- Section 3.1: Add explicit statement that assigner-value is an ASN.1 OID in
  dotted-decimal form, removing ambiguity with IP address syntax
- Section 3.2: Add "(CSR)" to section title for clarity on first use
- Section 3.2 / 4.2: Replace "octet-for-octet match" with "exactly match (no normalization, case folding, or encoding transformation is permitted)" to clarify the intent of the comparison requirement
- Section 6.1: Remove stale TODO comment from Enterprise PKI intro paragraph
- Section 6.1 / Attestation Posture: Reword unclear sentence about servers that rely on alternative authorization mechanisms for device identity

No normative changes. All edits are clarifications in response to AD review.

No normative change. All edits are clarifications in response to AD review